### PR TITLE
Fix/update api url

### DIFF
--- a/lib/http-methods/index.js
+++ b/lib/http-methods/index.js
@@ -18,7 +18,6 @@ const setAuthHeaders = (apiKey, origin) => {
   let headers = {
     Authorization: 'Bearer ' + apiKey,
     'Content-Type': 'application/json',
-    Accept: 'application/vnd.maxihost.v2+json',
   };
 
   if (origin) {

--- a/lib/http-methods/index.js
+++ b/lib/http-methods/index.js
@@ -103,7 +103,7 @@ const deleteRequest = async (path, headers) => {
 };
 
 const buildUrl = (path, searchParams = '') => {
-  const url = process.env.MAXIHOST_API_DOMAIN || 'https://api.maxihost.com';
+  const url = process.env.LATITUDE_API_DOMAIN || 'https://api.latitude.sh';
   return url + path + searchParams;
 };
 

--- a/lib/resources/api-version/test.js
+++ b/lib/resources/api-version/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 const data = {
   data: {

--- a/lib/resources/projects/members/test.js
+++ b/lib/resources/projects/members/test.js
@@ -4,7 +4,7 @@ const LatitudeShApi = new LatitudeSh('fake token', 'some-test.origin');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
+
   Origin: 'some-test.origin',
 };
 const projectId = 12345;

--- a/lib/resources/projects/sshKeys/test.js
+++ b/lib/resources/projects/sshKeys/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 const projectId = 12345;
 const data = {

--- a/lib/resources/projects/test.js
+++ b/lib/resources/projects/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 const data = {

--- a/lib/resources/regions/test.js
+++ b/lib/resources/regions/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {

--- a/lib/resources/servers/remote-access/test.js
+++ b/lib/resources/servers/remote-access/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {

--- a/lib/resources/servers/rescue-mode/test.js
+++ b/lib/resources/servers/rescue-mode/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {

--- a/lib/resources/teams/members/test.js
+++ b/lib/resources/teams/members/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {

--- a/lib/resources/teams/roles/test.js
+++ b/lib/resources/teams/roles/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 const data = {
   data: {

--- a/lib/resources/teams/test.js
+++ b/lib/resources/teams/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {

--- a/lib/resources/teams/user/test.js
+++ b/lib/resources/teams/user/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {

--- a/lib/resources/traffic/quota/test.js
+++ b/lib/resources/traffic/quota/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 const projectSlug = 'test-project-slug';
 

--- a/lib/resources/user/api-keys/test.js
+++ b/lib/resources/user/api-keys/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 const data = {
   data: {

--- a/lib/resources/user/profile/test.js
+++ b/lib/resources/user/profile/test.js
@@ -4,7 +4,6 @@ const LatitudeShApi = new LatitudeSh('fake token');
 const headers = {
   Authorization: 'Bearer fake token',
   'Content-Type': 'application/json',
-  Accept: 'application/vnd.maxihost.v2+json',
 };
 
 beforeEach(() => {


### PR DESCRIPTION
This PR updates the API Domain to use `LATITUDE_API_DOMAIN` env var and fallback it to the new `https://api.latitude.sh`.
It also removes versioning header  

1. Dashboard should work as expected when linked to this version
2. There should be no references to "maxihost" in the codebase (except on Changelog)