### PR TITLE
chore: adding node18 to CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,59 +2,57 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
 
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 18.x]
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: NPM install
-      run: npm ci
+      - name: NPM install
+        run: npm ci
 
-    - name: NPM Build
-      run: npm run build --if-present
+      - name: NPM Build
+        run: npm run build --if-present
 
-    - name: Run Tests
-      run: npm run test--ci
+      - name: Run Tests
+        run: npm run test--ci
 
   release:
-
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
 
     runs-on: ubuntu-latest
     needs: [build]
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
-    - name: NPM Install ci
-      run: npm ci
+      - name: NPM Install ci
+        run: npm ci
 
-    - name: Publish with Semantic Release
-      run: npx semantic-release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish with Semantic Release
+        run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: NPM Install ci
         run: npm ci


### PR DESCRIPTION
The release of the last commit [failed](https://github.com/latitudesh/latitudesh-nodejs/actions/runs/4105585289/jobs/7082667157) due to the Node version required by Semantic Release. According to [this doc](https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md), we need to run Node 18 on integration. 
I've added `18.x` under strategy, along with 12.x and 14.x. 
Since I'm not sure this is a safe move, I'm putting it up to review to learn what you guys think