### PR TITLE
feat(apiVersion): add method to list all api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ latitudeShApi.Profile.get().then((response) => {
 # Available API Methods
 
 - `ApiVersion.get` Params: `()`. [Reference](https://docs.latitude.sh/reference/get-current-version)
+- `ApiVersion.getAll` Params: `()`. [Reference](https://docs.latitude.sh/reference/get-api-versions)
 - `ApiVersion.update` Params: `(bodyData)`. [Reference](https://docs.latitude.sh/reference/update-current-version)
 
 - `Account.Regions.list`. Params: `(searchParams)`. **_Deprecated_**

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ latitudeShApi.Profile.get().then((response) => {
 # Available API Methods
 
 - `ApiVersion.get` Params: `()`. [Reference](https://docs.latitude.sh/reference/get-current-version)
-- `ApiVersion.getAll` Params: `()`. [Reference](https://docs.latitude.sh/reference/get-api-versions)
+- `ApiVersion.list` Params: `()`. [Reference](https://docs.latitude.sh/reference/get-api-versions)
 - `ApiVersion.update` Params: `(bodyData)`. [Reference](https://docs.latitude.sh/reference/update-current-version)
 
 - `Account.Regions.list`. Params: `(searchParams)`. **_Deprecated_**

--- a/lib/resources/api-version/index.js
+++ b/lib/resources/api-version/index.js
@@ -9,7 +9,7 @@ class ApiVersion {
     return this.LatitudeSh._get(`${this.baseUrl}/current_version`, headers);
   }
 
-  getAll() {
+  list() {
     const headers = this.LatitudeSh._headers;
     return this.LatitudeSh._get(`${this.baseUrl}/api_versions`, headers);
   }

--- a/lib/resources/api-version/index.js
+++ b/lib/resources/api-version/index.js
@@ -9,6 +9,11 @@ class ApiVersion {
     return this.LatitudeSh._get(`${this.baseUrl}/current_version`, headers);
   }
 
+  getAll() {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._get(`${this.baseUrl}/api_versions`, headers);
+  }
+
   update(bodyData) {
     const headers = this.LatitudeSh._headers;
     return this.LatitudeSh._patch(

--- a/lib/resources/api-version/test.js
+++ b/lib/resources/api-version/test.js
@@ -33,7 +33,7 @@ describe('api version', () => {
     LatitudeSh._get = jest.fn(() => {
       return { body: { success: true } };
     });
-    LatitudeShApi.ApiVersion.getAll();
+    LatitudeShApi.ApiVersion.list();
     await expect(LatitudeSh._get).toHaveBeenCalledWith(path, headers);
   });
 

--- a/lib/resources/api-version/test.js
+++ b/lib/resources/api-version/test.js
@@ -28,6 +28,15 @@ describe('api version', () => {
     await expect(LatitudeSh._get).toHaveBeenCalledWith(path, headers);
   });
 
+  it('call get request to get all api versions', async () => {
+    const path = '/auth/api_versions';
+    LatitudeSh._get = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.ApiVersion.getAll();
+    await expect(LatitudeSh._get).toHaveBeenCalledWith(path, headers);
+  });
+
   it('call patch request to update api version', async () => {
     const path = '/auth/update_version';
     LatitudeSh._patch = jest.fn(() => {


### PR DESCRIPTION
implement a new method that add a list rote to return all api version. This PR will support [PD-3304](https://latitude.atlassian.net/browse/PD-3304)

[PD-3304]: https://latitude.atlassian.net/browse/PD-3304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ