### PR TITLE
feat: schedule and unschedule deletion endpoint

### DIFF
--- a/lib/resources/servers/actions/index.js
+++ b/lib/resources/servers/actions/index.js
@@ -28,6 +28,22 @@ class Actions {
       bodyData
     );
   }
+  scheduleDeletion(serverId, bodyData) {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._post(
+      '/servers/' + serverId + '/schedule_deletion',
+      headers,
+      bodyData
+    );
+  }
+  unscheduleDeletion(serverId) {
+    const headers = this.LatitudeSh._headers;
+    this.LatitudeSh._delete(
+      '/servers/' + serverId + '/schedule_deletion',
+      headers
+    );
+    return;
+  }
 
   /**
    * @deprecated

--- a/lib/resources/servers/actions/index.js
+++ b/lib/resources/servers/actions/index.js
@@ -28,12 +28,11 @@ class Actions {
       bodyData
     );
   }
-  scheduleDeletion(serverId, bodyData) {
+  scheduleDeletion(serverId) {
     const headers = this.LatitudeSh._headers;
     return this.LatitudeSh._post(
       '/servers/' + serverId + '/schedule_deletion',
-      headers,
-      bodyData
+      headers
     );
   }
   unscheduleDeletion(serverId) {


### PR DESCRIPTION
#### What does this PR do?

Add enpoints for scheduling and unscheduling server deletion. 
Scheduled deletion [does not take any parameter](https://docs.latitude.sh/reference/server-schedule-deletion), since it will just set the delete date to the end of the cycle. 

#### How should this be manually tested?

1. Link it with [dashboard PR]
2. Scheduling and unscheduling should work

 
#### What are the relevant issues?

 [PD-3552](https://latitude.atlassian.net/browse/PD-3552)


[PD-3552]: https://latitude.atlassian.net/browse/PD-3552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ