### PR TITLE
Pd 3647 manage tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ latitudeShApi.Profile.get().then((response) => {
 - `Server.Actions.getRemoteAccess`. Params: `(serverId)`. **_Deprecated_**
 - `Server.Actions.managePower`. Params: `(serverId, postData)` [Reference](https://docs.latitude.sh/reference/create-server-action)
 - `Server.Actions.reinstall`. Params: `(serverId, bodyData)`. [Reference](https://docs.latitude.sh/reference/create-server-reinstall)
+- `Server.Actions.scheduleDeletion`. Params: `(serverId)`. [Reference](https://docs.latitude.sh/reference/server-schedule-deletion)
+- `Server.Actions.unscheduleDeletion`. Params: `(serverId)`. [Reference](https://docs.latitude.sh/reference/server-unschedule-deletion)
 
 - `Server.DeployConfig.get`. Params: `(serverId)`. [Reference](https://docs.latitude.sh/reference/get-server-deploy-config)
 - `Server.DeployConfig.update`. Params: `(serverId, bodyData)`. [Reference](https://docs.latitude.sh/reference/update-server-deploy-config)
@@ -97,6 +99,11 @@ latitudeShApi.Profile.get().then((response) => {
 - `Teams.Members.create`. Params: `(bodyData)`. [Reference](https://docs.latitude.sh/reference/post-team-members)
 - `Teams.Members.delete`. Params: `(memberId)`. [Reference](https://docs.latitude.sh/reference/destroy-team-member)
 - `Teams.Members.list`. Params: `(searchParams)`. [Reference](https://docs.latitude.sh/reference/get-team-members)
+
+- `Teams.Tags.list`. Params: `()`. [Reference](https://docs.latitude.sh/reference/get-tags)
+- `Teams.Tags.create`. Params: `(bodyData)`. [Reference](https://docs.latitude.sh/reference/create-tag)
+- `Teams.Tags.update`. Params: `(tagId, bodyData)`. [Reference](https://docs.latitude.sh/reference/update-tag)
+- `Teams.Tags.delete`. Params: `(tagId)`. [Reference](https://docs.latitude.sh/reference/destroy-tag)
 
 - `Teams.User.listTeams`. Params: `(searchParams)`. [Reference](https://docs.latitude.sh/reference/get-user-teams)
 

--- a/lib/resources/teams/index.js
+++ b/lib/resources/teams/index.js
@@ -1,6 +1,7 @@
 const User = require('./user/index.js');
 const Members = require('./members/index.js');
 const Roles = require('./roles/index.js');
+const Tags = require('./tags/index.js');
 
 class Teams {
   constructor(LatitudeSh) {
@@ -30,4 +31,5 @@ module.exports = LatitudeSh => {
   LatitudeSh.prototype.Teams.User = new User(LatitudeSh);
   LatitudeSh.prototype.Teams.Members = new Members(LatitudeSh);
   LatitudeSh.prototype.Teams.Roles = new Roles(LatitudeSh);
+  LatitudeSh.prototype.Teams.Tags = new Tags(LatitudeSh);
 };

--- a/lib/resources/teams/tags/index.js
+++ b/lib/resources/teams/tags/index.js
@@ -14,6 +14,14 @@ class Tags {
     return this.LatitudeSh._post(this.baseUrl, headers, bodyData);
   }
 
+  update(tagId, bodyData) {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._patch(
+      `${this.baseUrl}/${tagId}`,
+      headers,
+      bodyData
+    );
+  }
   delete(tagId) {
     const headers = this.LatitudeSh._headers;
     return this.LatitudeSh._delete(`${this.baseUrl}/${tagId}`, headers);

--- a/lib/resources/teams/tags/index.js
+++ b/lib/resources/teams/tags/index.js
@@ -1,0 +1,23 @@
+class Tags {
+  constructor(LatitudeSh) {
+    this.LatitudeSh = LatitudeSh;
+    this.baseUrl = '/tags';
+  }
+
+  list() {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._get(this.baseUrl, headers);
+  }
+
+  create(bodyData) {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._post(this.baseUrl, headers, bodyData);
+  }
+
+  delete(tagId) {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._delete(`${this.baseUrl}/${tagId}`, headers);
+  }
+}
+
+module.exports = Tags;

--- a/lib/resources/teams/tags/test.js
+++ b/lib/resources/teams/tags/test.js
@@ -10,7 +10,7 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe('get team tags', () => {
+describe('team tags routines', () => {
   it('call get request to list team tags', async () => {
     const path = '/tags';
     LatitudeSh._get = jest.fn(() => {
@@ -42,7 +42,32 @@ describe('get team tags', () => {
       },
     });
   });
-  it('call delete with correct para', async () => {
+  it('call patch with correct body', async () => {
+    const tagId = 'tag_yN8bR7PDpyfxqkYdjykmS50N5rL';
+    const path = `/tags/${tagId}`;
+    console.log(path);
+    const tagObj = {
+      name: 'EditedtagName',
+      color: '#fff000',
+      description: 'tagDescription',
+    };
+    LatitudeSh._patch = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Teams.Tags.update(tagId, {
+      data: {
+        type: 'tags',
+        attributes: tagObj,
+      },
+    });
+    await expect(LatitudeSh._patch).toHaveBeenCalledWith(path, headers, {
+      data: {
+        type: 'tags',
+        attributes: tagObj,
+      },
+    });
+  });
+  it('call delete with correct param', async () => {
     const tagId = 'tag_yN8bR7PDpyfxqkYdjykmS50N5rL';
     const path = `/tags/${tagId}`;
 

--- a/lib/resources/teams/tags/test.js
+++ b/lib/resources/teams/tags/test.js
@@ -1,0 +1,55 @@
+import LatitudeSh from '../../../latitudesh.js';
+
+const LatitudeShApi = new LatitudeSh('fake token');
+const headers = {
+  Authorization: 'Bearer fake token',
+  'Content-Type': 'application/json',
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('get team tags', () => {
+  it('call get request to list team tags', async () => {
+    const path = '/tags';
+    LatitudeSh._get = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Teams.Tags.list();
+    await expect(LatitudeSh._get).toHaveBeenCalledWith(path, headers);
+  });
+  it('call post with correct body', async () => {
+    const path = '/tags';
+    const tagObj = {
+      name: 'tagName',
+      color: '#fff000',
+      description: 'tagDescription',
+    };
+    LatitudeSh._post = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Teams.Tags.create({
+      data: {
+        type: 'tags',
+        attributes: tagObj,
+      },
+    });
+    await expect(LatitudeSh._post).toHaveBeenCalledWith(path, headers, {
+      data: {
+        type: 'tags',
+        attributes: tagObj,
+      },
+    });
+  });
+  it('call delete with correct para', async () => {
+    const tagId = 'tag_yN8bR7PDpyfxqkYdjykmS50N5rL';
+    const path = `/tags/${tagId}`;
+
+    LatitudeSh._delete = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Teams.Tags.delete(tagId);
+    await expect(LatitudeSh._delete).toHaveBeenCalledWith(path, headers);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

Adds support for tag management (list, create, update and delete)

This route is a subset of `Teams` (similar to Members)

#### How should this be manually tested?

1. `latitudeShApi.Teams.Tags.update`, `latitudeShApi.Teams.Tags.create`, `latitudeShApi.Teams.Tags.delete` and `latitudeShApi.Teams.Tags.list` should work

#### Any background context you want to provide?

#### What are the relevant issues?
[PD-3647](https://latitude.atlassian.net/browse/PD-3647)

#### Screenshots (if appropriate)

#### Questions:


[PD-3647]: https://latitude.atlassian.net/browse/PD-3647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ