### PR TITLE
feat: add lock/unlock server actions

### DIFF
--- a/lib/resources/servers/actions/index.js
+++ b/lib/resources/servers/actions/index.js
@@ -44,7 +44,7 @@ class Actions {
     return;
   }
 
-  lockDevice(serverId) {
+  lock(serverId) {
     const headers = this.LatitudeSh._headers;
     return this.LatitudeSh._post(
       '/servers/' + serverId + '/lock',
@@ -52,7 +52,7 @@ class Actions {
     );
   }
 
-  unlockDevice(serverId) {
+  unlock(serverId) {
     const headers = this.LatitudeSh._headers;
     return this.LatitudeSh._post(
       '/servers/' + serverId + '/unlock',

--- a/lib/resources/servers/actions/index.js
+++ b/lib/resources/servers/actions/index.js
@@ -44,6 +44,22 @@ class Actions {
     return;
   }
 
+  lockDevice(serverId) {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._post(
+      '/servers/' + serverId + '/lock',
+      headers
+    );
+  }
+
+  unlockDevice(serverId) {
+    const headers = this.LatitudeSh._headers;
+    return this.LatitudeSh._post(
+      '/servers/' + serverId + '/unlock',
+      headers
+    );
+  }
+
   /**
    * @deprecated
    */

--- a/lib/resources/servers/actions/test.js
+++ b/lib/resources/servers/actions/test.js
@@ -69,6 +69,50 @@ describe('get reinstall', () => {
   });
 });
 
+describe('lock device', () => {
+  it('call post request with right params', async () => {
+    const path = '/servers/' + serverId + '/lock';
+    LatitudeSh._post = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Server.Actions.lockDevice(serverId);
+    await expect(LatitudeSh._post).toHaveBeenCalledWith(
+      path,
+      LatitudeSh._headers
+    );
+  });
+
+  it('call get request with wrong params', async () => {
+    const error = new Error('Async error');
+    LatitudeSh._post = jest.fn().mockRejectedValue(error);
+    await LatitudeShApi.Server.Actions.lockDevice(serverId).catch(e => {
+      expect(e).toBe(error);
+    });
+  });
+})
+
+describe('unlock device', () => {
+  it('call post request with right params', async () => {
+    const path = '/servers/' + serverId + '/unlock';
+    LatitudeSh._post = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Server.Actions.unlockDevice(serverId);
+    await expect(LatitudeSh._post).toHaveBeenCalledWith(
+      path,
+      LatitudeSh._headers
+    );
+  });
+
+  it('call get request with wrong params', async () => {
+    const error = new Error('Async error');
+    LatitudeSh._post = jest.fn().mockRejectedValue(error);
+    await LatitudeShApi.Server.Actions.unlockDevice(serverId).catch(e => {
+      expect(e).toBe(error);
+    });
+  });
+})
+
 describe('schedule reinstall', () => {
   it('call post request with right params', async () => {
     const path = '/servers/' + serverId + '/reinstall';

--- a/lib/resources/servers/actions/test.js
+++ b/lib/resources/servers/actions/test.js
@@ -75,7 +75,7 @@ describe('lock device', () => {
     LatitudeSh._post = jest.fn(() => {
       return { body: { success: true } };
     });
-    LatitudeShApi.Server.Actions.lockDevice(serverId);
+    LatitudeShApi.Server.Actions.lock(serverId);
     await expect(LatitudeSh._post).toHaveBeenCalledWith(
       path,
       LatitudeSh._headers
@@ -85,7 +85,7 @@ describe('lock device', () => {
   it('call get request with wrong params', async () => {
     const error = new Error('Async error');
     LatitudeSh._post = jest.fn().mockRejectedValue(error);
-    await LatitudeShApi.Server.Actions.lockDevice(serverId).catch(e => {
+    await LatitudeShApi.Server.Actions.lock(serverId).catch(e => {
       expect(e).toBe(error);
     });
   });
@@ -97,7 +97,7 @@ describe('unlock device', () => {
     LatitudeSh._post = jest.fn(() => {
       return { body: { success: true } };
     });
-    LatitudeShApi.Server.Actions.unlockDevice(serverId);
+    LatitudeShApi.Server.Actions.unlock(serverId);
     await expect(LatitudeSh._post).toHaveBeenCalledWith(
       path,
       LatitudeSh._headers
@@ -107,7 +107,7 @@ describe('unlock device', () => {
   it('call get request with wrong params', async () => {
     const error = new Error('Async error');
     LatitudeSh._post = jest.fn().mockRejectedValue(error);
-    await LatitudeShApi.Server.Actions.unlockDevice(serverId).catch(e => {
+    await LatitudeShApi.Server.Actions.unlock(serverId).catch(e => {
       expect(e).toBe(error);
     });
   });


### PR DESCRIPTION
This PR introduces a new API route to lock and unlock a server.  Only users with Administrator or Owner roles can perform these actions.

This route is a subset of server actions (similar to reboot or turnOn rotes)

#### How should this be manually tested?
`latitudeShApi.Server.Actions.lockDevice`, and `latitudeShApi.Server.Actions.unlockDevice` should work
