### PR TITLE
chore: support for reason on server delete

### DIFF
--- a/lib/resources/servers/index.js
+++ b/lib/resources/servers/index.js
@@ -43,9 +43,11 @@ class Device {
     );
   }
 
-  delete(deviceId) {
+  delete(deviceId, reason) {
+    const reasonParam = reason ? '?' + new URLSearchParams({ reason }) : '';
+
     return this.LatitudeSh._delete(
-      '/servers/' + deviceId,
+      '/servers/' + deviceId + reasonParam,
       this.LatitudeSh._headers
     );
   }


### PR DESCRIPTION
## Overview

Adds support to `reason` parameter on `Server.delete`

[API Reference](https://docs.latitude.sh/reference/destroy-server)

#### How should this be manually tested?

1. Try #1768 with this new API
2. Churn reasons should be received as a single string

### Any background context you want to provide?

- [Include any additional context that might help reviewers understand the PR.]

### Questions:

- [Include any questions you have for the reviewers or points you'd like to be especially reviewed.]

### Screenshots (if appropriate)

### What are the relevant issues?

- [List any relevant issues or JIRA tasks related to this PR.]

---

### Review Guidelines

1. Carry out the testing flow on BrowserStack, using at least two different environments from the initially tested one.
3. Check the development Bugsnag for any error logs related to the test.
4. Review this Pull Request and comment on the environments in which the tests were run.

### Review Checklist

Before merging this PR, please ensure that:

- [ ] The testing requirements were fully understood and met.
- [ ] The tests were carried out as requested and all use cases are covered.
- [ ] (If appropriate) The mobile environment of the website was checked and does not present any side effects.
- [ ] The Bugsnag logs have been checked and no new related errors are present.
- [ ] The code is clean and well-commented.
- [ ] This PR is coherent with the scope and does not include unnecessary changes.
