### PR TITLE
Pd 4834/list firewall assignments by server

### DIFF
--- a/lib/resources/firewall/index.js
+++ b/lib/resources/firewall/index.js
@@ -65,6 +65,16 @@ class Firewall {
       this.LatitudeSh._headers
     );
   }
+
+  listFirewallsForServer(searchParams = '') {
+    searchParams = new URLSearchParams(searchParams).toString();
+
+    return this.LatitudeSh._get(
+      `/firewalls/assignments`,
+      this.LatitudeSh._headers,
+      searchParams
+    );
+  }
 }
 
 module.exports = LatitudeSh => {

--- a/lib/resources/firewall/test.js
+++ b/lib/resources/firewall/test.js
@@ -112,4 +112,19 @@ describe('Firewall', () => {
     LatitudeShApi.Firewall.delete(firewallId);
     await expect(LatitudeSh._delete).toHaveBeenCalledWith(path, headers);
   });
+
+  it('should list firewalls for server', async () => {
+    const path = '/firewalls/assignments';
+    const searchParams = { server_id: 12345 };
+    const searchParamsParsed = new URLSearchParams(searchParams).toString();
+    LatitudeSh._get = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.Firewall.listFirewallsForServer(searchParams);
+    await expect(LatitudeSh._get).toHaveBeenCalledWith(
+      path,
+      headers,
+      searchParamsParsed
+    );
+  });
 });


### PR DESCRIPTION
Adds support for `listFirewallsForServer`, required for  https://latitude.atlassian.net/browse/PD-4834


On https://github.com/latitudesh/latitude.sh/pull/2573 , `listFirewallsForServer` should return firewalls that are assigned to server.