### PR TITLE
chore: adding SEMANTIC_RELEASE_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Publish with Semantic Release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds new token to grant permission to Semantic Releases 


Per Claude:
> Your current workflow issue:
Your semantic-release is trying to use the default GITHUB_TOKEN (which GitHub provides automatically), but that token can't bypass your branch protection rules. That's why you're getting the "Changes must be made through a pull request" error.