### PR TITLE
feat(managed-databases): add update method for PATCH support

### DIFF
--- a/lib/resources/managed-databases/index.js
+++ b/lib/resources/managed-databases/index.js
@@ -29,6 +29,14 @@ class ManagedDatabases {
     );
   }
 
+  update(databaseId, bodyData) {
+    return this.LatitudeSh._patch(
+      '/managed_databases/' + databaseId,
+      this.LatitudeSh._headers,
+      bodyData
+    );
+  }
+
   delete(databaseId) {
     return this.LatitudeSh._delete(
       '/managed_databases/' + databaseId,

--- a/lib/resources/managed-databases/test.js
+++ b/lib/resources/managed-databases/test.js
@@ -110,6 +110,38 @@ describe('create managed database', () => {
   });
 });
 
+describe('update managed database', () => {
+  const updateData = {
+    data: {
+      type: 'managed_databases',
+      attributes: {
+        trusted_sources: ['1.2.3.4/32', '10.0.0.0/8'],
+      },
+    },
+  };
+
+  it('call patch request with right params', async () => {
+    const path = '/managed_databases/' + databaseId;
+    LatitudeSh._patch = jest.fn(() => {
+      return { body: { success: true } };
+    });
+    LatitudeShApi.ManagedDatabases.update(databaseId, updateData);
+    await expect(LatitudeSh._patch).toHaveBeenCalledWith(
+      path,
+      LatitudeSh._headers,
+      updateData
+    );
+  });
+
+  it('call patch request with wrong params', async () => {
+    const error = new Error('Async error');
+    LatitudeSh._patch = jest.fn().mockRejectedValue(error);
+    await LatitudeShApi.ManagedDatabases.update(databaseId, updateData).catch(e => {
+      expect(e).toBe(error);
+    });
+  });
+});
+
 describe('delete managed database', () => {
   it('call delete request with right params', async () => {
     const path = '/managed_databases/' + databaseId;


### PR DESCRIPTION
## Summary

- Add `update(databaseId, bodyData)` method to `ManagedDatabases` resource for `PATCH /managed_databases/:id` support
- Used by the dashboard to update trusted sources (IP whitelisting) on ClickHouse managed databases

## Related PRs

- **API:** https://github.com/latitudesh/API/pull/4525
- **Frontend:** https://github.com/latitudesh/latitude.sh/pull/3451

## Files changed

- `lib/resources/managed-databases/index.js` — Added `update` method
- `lib/resources/managed-databases/test.js` — Added test cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)