### PR TITLE
fix(ci): drop EOL Node 16 from matrix for jest 30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "directories": {
     "lib": "lib"
+  },
+  "engines": {
+    "node": ">=18.14.0"
   }
 }


### PR DESCRIPTION
## Problem

CI fails on master:

```
TypeError: (0 , _nodeOs(...).availableParallelism) is not a function
    at getMaxWorkers (node_modules/jest-config/build/index.js:810:56)
```

`os.availableParallelism()` was added in **Node 18.14 / 20**. jest 30 (bumped recently) calls it, so the **Node 16.x** matrix leg crashes. Node 16 has been EOL since Sept 2023.

## Fix

- CI matrix `[16.x, 18.x, 20.x]` → `[18.x, 20.x, 22.x]`
- Add `engines.node: ">=18.14.0"` to document jest 30's floor and surface incompatible environments early

## Verification

- All 383 tests pass locally (Node 24)
- jest 30 declares `engines.node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0` — the new matrix is fully within range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI matrix and package metadata only; no application or library runtime logic changes.
> 
> **Overview**
> Updates CI to stop testing on **Node 16.x** (EOL and incompatible with jest 30’s use of `os.availableParallelism()`), and runs the matrix on **18.x, 20.x, and 22.x** instead.
> 
> Adds **`engines.node`: `>=18.14.0`** in `package.json` so the minimum Node version matches jest 30 and fails fast in unsupported environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcb66b1d255ef9c7d4a9c7f026dfe5ee3dfb97d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->